### PR TITLE
feat(xt): add log aggregation helper

### DIFF
--- a/xt/logging.go
+++ b/xt/logging.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023, Geert JM Vanderkelen
+ */
+
+package xt
+
+import (
+	"encoding/json"
+	"io"
+	"regexp"
+	"sync"
+	"testing"
+)
+
+func NewLogAgg() *LogAgg {
+	return &LogAgg{}
+}
+
+// LogAgg is a very basic log aggregation writer which can be used to find
+// entries. This is really just useful for tests and also not really specific to logging.
+type LogAgg struct {
+	entries []string
+	mu      sync.RWMutex
+}
+
+var _ io.Writer = (*LogAgg)(nil)
+
+func (l *LogAgg) Write(p []byte) (n int, err error) {
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.entries = append(l.entries, string(p))
+
+	return len(p), nil
+}
+
+func (l *LogAgg) Reset() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.entries = nil
+}
+
+func (l *LogAgg) Find(t *testing.T, pattern string) string {
+
+	t.Helper()
+
+	re := regexp.MustCompile(pattern)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	var line string
+	for _, line = range l.entries {
+		if re.MatchString(line) {
+			break
+		}
+	}
+
+	return line
+}
+
+func (l *LogAgg) FindJSON(t *testing.T, pattern string) map[string]any {
+
+	t.Helper()
+
+	line := l.Find(t, pattern)
+
+	if line == "" {
+		t.Fatalf("failed finding entry matching %s", pattern)
+	}
+
+	result := map[string]any{}
+	OK(t, json.Unmarshal([]byte(line), &result))
+
+	return result
+}

--- a/xt/logging_test.go
+++ b/xt/logging_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, Geert JM Vanderkelen
+ */
+
+package xt_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golistic/xgo/xt"
+)
+
+func TestLogAgg(t *testing.T) {
+	t.Run("write, find, reset", func(t *testing.T) {
+		la := xt.NewLogAgg()
+		for i := 1; i <= 3; i++ {
+			_, err := la.Write([]byte(fmt.Sprintf("line %d", i)))
+			xt.OK(t, err)
+		}
+
+		for i := 1; i <= 3; i++ {
+			exp := fmt.Sprintf("line %d", i)
+			xt.Eq(t, exp, la.Find(t, exp))
+		}
+
+		la.Reset()
+
+		for i := 1; i <= 3; i++ {
+			xt.Eq(t, "", la.Find(t, fmt.Sprintf("line %d", i)))
+		}
+	})
+
+	t.Run("find JSON", func(t *testing.T) {
+		la := xt.NewLogAgg()
+		for i := 1; i <= 3; i++ {
+			_, err := la.Write([]byte(fmt.Sprintf(`{"line": "data %d"}`, i)))
+			xt.OK(t, err)
+		}
+
+		for i := 1; i <= 3; i++ {
+			exp := fmt.Sprintf("data %d", i)
+			have := la.FindJSON(t, exp)
+			xt.Eq(t, exp, have["line"])
+		}
+	})
+}


### PR DESCRIPTION
We add `xt.LogAgg` which implements `io.Writer` and can be used for example as a logger output. Lines are stored and can be searched.