### PR TITLE
feat(xtime): add Midday() and UTCMidday()

### DIFF
--- a/xtime/clock.go
+++ b/xtime/clock.go
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, Geert JM Vanderkelen
+ */
+
+package xtime
+
+import "time"
+
+// Midday returns the time corresponding to 12:00:00 on the current local date.
+func Midday() time.Time {
+
+	n := time.Now()
+
+	return time.Date(n.Year(), n.Month(), n.Day(), 12, 0, 0, 0, time.Local)
+}
+
+// UTCMidday returns the current time adjusted to midday (12:00:00) in UTC.
+func UTCMidday() time.Time {
+
+	now := time.Now().UTC()
+
+	return time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, time.UTC)
+}

--- a/xtime/clock_test.go
+++ b/xtime/clock_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, Geert JM Vanderkelen
+ */
+
+package xtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golistic/xgo/xt"
+)
+
+func TestUTCMidday(t *testing.T) {
+
+	tests := []struct {
+		name string
+		want time.Time
+	}{
+		{
+			name: "UTC_Midday_Today",
+			want: time.Date(time.Now().UTC().Year(), time.Now().UTC().Month(), time.Now().UTC().Day(), 12, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			xt.Eq(t, tt.want, UTCMidday())
+		})
+	}
+}
+
+func TestMidday(t *testing.T) {
+
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want func() time.Time
+	}{
+		{
+			name: "local midday",
+			want: func() time.Time {
+				n := time.Now()
+				return time.Date(n.Year(), n.Month(), n.Day(), 12, 0, 0, 0, n.Location())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			xt.Eq(t, tt.want(), Midday())
+		})
+	}
+}


### PR DESCRIPTION
In this commit, we introduce two new functions: `Midday` and `UTCMidday`.

The `Midday` function returns the current local time adjusted to midday (12:00 PM),
while the `UTCMidday` function returns the current time in the UTC timezone, adjusted
to midday. These functions are valuable for creating a standard timestamp where the
specific time is not as significant as the date.