### PR TITLE
feat(xstring): add ScanTokens

### DIFF
--- a/xstrings/scan.go
+++ b/xstrings/scan.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Geert JM Vanderkelen
+ */
+
+package xstrings
+
+import (
+	"strings"
+	"unicode"
+)
+
+// ScanTokens scans a string and returns a slice of tokens.
+//
+// Tokens are separated by whitespace, unless they are within quotes.
+// If a token is within quotes, the whitespace is preserved within the token.
+// Any character that is not whitespace or a quote is part of a token.
+func ScanTokens(s string) []string {
+
+	var tokens []string
+	var inQuotes rune
+
+	var currToken strings.Builder
+
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return []string{}
+	}
+
+	for _, r := range s {
+		switch {
+		case unicode.IsSpace(r):
+			if inQuotes != 0 {
+				currToken.WriteRune(r)
+			} else if currToken.Len() > 0 {
+				tokens = append(tokens, currToken.String())
+				currToken.Reset()
+			}
+		case r == '"' || r == '\'':
+			if inQuotes == 0 {
+				inQuotes = r
+				continue
+			} else if inQuotes == r {
+				inQuotes = 0
+				continue
+			}
+			fallthrough
+		default:
+			currToken.WriteRune(r)
+		}
+	}
+
+	if currToken.Len() > 0 {
+		tokens = append(tokens, currToken.String())
+	}
+
+	return tokens
+}

--- a/xstrings/scan_test.go
+++ b/xstrings/scan_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, Geert JM Vanderkelen
+ */
+
+package xstrings
+
+import (
+	"testing"
+
+	"github.com/golistic/xgo/xt"
+)
+
+func TestScanTokens(t *testing.T) {
+
+	var cases = []struct {
+		got  string
+		want []string
+	}{
+		{
+			" simple   with  variable spaces in Between    ",
+			[]string{"simple", "with", "variable", "spaces", "in", "Between"},
+		},
+		{
+			"with \n newline",
+			[]string{"with", "newline"},
+		},
+		{
+			`token is "double quoted"`,
+			[]string{"token", "is", "double quoted"},
+		},
+		{
+			`token is "double quoted" in middle of string`,
+			[]string{"token", "is", "double quoted", "in", "middle", "of", "string"},
+		},
+		{
+			`token is 'single quoted' in middle of string`,
+			[]string{"token", "is", "single quoted", "in", "middle", "of", "string"},
+		},
+		{
+			`single in doubles "a string's token" `,
+			[]string{"single", "in", "doubles", "a string's token"},
+		},
+		{
+			`doubles in singles 'token with "double" quotes' `,
+			[]string{"doubles", "in", "singles", `token with "double" quotes`},
+		},
+		{
+			``,
+			[]string{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			xt.Eq(t, c.want, ScanTokens(c.got))
+		})
+	}
+}


### PR DESCRIPTION
ScanTokens scans a string and returns a slice of tokens.

Tokens are separated by whitespace, unless they are within quotes. If a token is within quotes, the whitespace is preserved within the token. Any character that is not whitespace or a quote is part of a token.