### PR TITLE
feat(xt): add xt.ErrorIs and envvar XT_NO_COLORS

### DIFF
--- a/xt/errors.go
+++ b/xt/errors.go
@@ -3,8 +3,10 @@
 package xt
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"testing"
 )
 
@@ -54,4 +56,32 @@ func ko(t *testing.T, out io.Writer, err error, messages ...string) {
 		}
 		fatal(t, out, fmt.Sprintf("\u001B[31;1mexpected error\u001B[0m"), messages...)
 	}
+}
+
+func ErrorIs(t *testing.T, want, have error, messages ...string) {
+
+	TestHelper(t)
+
+	errorIs(t, nil, want, have, messages...)
+}
+
+func errorIs(t *testing.T, out io.Writer, want, have error, messages ...string) bool {
+
+	TestHelper(t)
+
+	if !errors.Is(have, want) {
+		diff := fmt.Sprintf("\n\u001b[31;1mwant error:\t\u001b[0m%v\n\u001b[31;1mwrapped in:\t\u001b[0m%v\n", want, have)
+
+		if _, ok := os.LookupEnv(EnvNoColors); ok {
+			diff = fmt.Sprintf("\nwant error:\t%v\nwrapped in:\t%v\n", want, have)
+		}
+
+		if len(messages) > 0 {
+			messages = append([]string{"--"}, messages...)
+		}
+		fatal(t, out, diff, messages...)
+		return false
+	}
+
+	return true
 }

--- a/xt/errors_test.go
+++ b/xt/errors_test.go
@@ -14,11 +14,13 @@ func TestOK(t *testing.T) {
 	})
 
 	t.Run("error is not nil", func(t *testing.T) {
-		have := bytes.NewBuffer(nil)
-		ok(t, have, fmt.Errorf("I am error"), "really wanted no error")
+		out := bytes.NewBuffer(nil)
+
+		ok(t, out, fmt.Errorf("I am error"), "really wanted no error")
 		exp := []byte("\u001B[31;1mexpected no error, got:\u001B[0m\nI am error\n\n--\nreally wanted no error\n")
-		if !bytes.Equal(exp, have.Bytes()) {
-			t.Fatal("expected:", string(exp), have.String())
+
+		if !bytes.Equal(exp, out.Bytes()) {
+			t.Fatal("expected:", string(exp), out.String())
 		}
 	})
 }
@@ -29,12 +31,53 @@ func TestKO(t *testing.T) {
 	})
 
 	t.Run("error is nil", func(t *testing.T) {
-		have := bytes.NewBuffer(nil)
-		ko(t, have, nil, "really wanted an error")
+		out := bytes.NewBuffer(nil)
+
+		ko(t, out, nil, "really wanted an error")
 		exp := []byte("\u001B[31;1mexpected error\u001B[0m\n\n--\nreally wanted an error\n")
-		fmt.Println(have.String())
-		if !bytes.Equal(exp, have.Bytes()) {
-			t.Fatal("expected:", string(exp), have.String())
+
+		fmt.Println(out.String())
+
+		if !bytes.Equal(exp, out.Bytes()) {
+			t.Fatal("expected:", string(exp), out.String())
+		}
+	})
+}
+
+func TestErrorIs(t *testing.T) {
+	t.Run("non-wrapped error does not match", func(t *testing.T) {
+		out := bytes.NewBuffer(nil)
+		wantErr := fmt.Errorf("I am error")
+		gotErr := fmt.Errorf("actual error")
+
+		errorIs(t, out, wantErr, gotErr)
+
+		wantOutput := `
+want error:	I am error
+wrapped in:	actual error
+`
+		if wantOutput != out.String() {
+			t.Fatal("want:", wantOutput, out.String())
+		}
+	})
+
+	t.Run("wrapped error does match", func(t *testing.T) {
+		out := bytes.NewBuffer(nil)
+		wantErr := fmt.Errorf("I am error")
+		haveError := fmt.Errorf("actual error: %w", wantErr)
+
+		if !errorIs(t, out, wantErr, haveError) {
+			t.Fatal("expected success", "have:", out.String())
+		}
+	})
+
+	t.Run("not wrapped error does match", func(t *testing.T) {
+		out := bytes.NewBuffer(nil)
+		wantErr := fmt.Errorf("I am error")
+		haveError := wantErr
+
+		if !errorIs(t, out, wantErr, haveError) {
+			t.Fatal("expected success", "have:", out.String())
 		}
 	})
 }

--- a/xt/main_test.go
+++ b/xt/main_test.go
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Geert JM Vanderkelen
+ */
+
+package xt
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_ = os.Setenv(EnvNoColors, "")
+
+	os.Exit(m.Run())
+}

--- a/xt/utils.go
+++ b/xt/utils.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 )
 
+const EnvNoColors = "XT_NO_COLORS"
+
 var TestHelper = (*testing.T).Helper
 
 func fatal(t *testing.T, out io.Writer, mainMsg string, messages ...string) {


### PR DESCRIPTION
We add `xt.ErrorIs` to check for wrapped errors, making `xt.KO` not needed when the error needs
to be verified.

We also add the possibility to turn of colors in output of xt using the environmental variable
`XT_NO_COLORS`. This is mostly to make testing easier, but can useful in other situations as well.